### PR TITLE
Add prefer-const rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const config = {
     plugins: ['jsx-a11y', 'package-json', 'react'],
     extends: ['plugin:jsx-a11y/recommended', 'plugin:package-json/recommended'],
     rules: {
+        'prefer-const':'error',
         'no-unused-vars': 'error',
         'react/jsx-uses-vars': 'error',
         'react/jsx-uses-react': 'error'

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const config = {
     plugins: ['jsx-a11y', 'package-json', 'react'],
     extends: ['plugin:jsx-a11y/recommended', 'plugin:package-json/recommended'],
     rules: {
-        'prefer-const':'error',
+        'prefer-const': 'error',
         'no-unused-vars': 'error',
         'react/jsx-uses-vars': 'error',
         'react/jsx-uses-react': 'error'


### PR DESCRIPTION
Based on [this comment](https://github.com/magento-research/pwa-studio/pull/797#discussion_r270098134) it seems like we don't have a rule for preferring const when a variable is not reassigned. To fix this we can add the rule `'prefer-const':'error'` which is documented [here](https://eslint.org/docs/rules/prefer-const).

Before adding the rule, `yarn run lint` passes with no errors.

After adding the rule, `yarn run lint` fails with errors like the following:

```
/Users/rugh/code/pwa-studio/packages/venia-concept/src/util/getFilterParamsFromUrl.js
  6:9  error  'urlFilterParams' is never reassigned. Use 'const' instead  prefer-const
```
