### PR TITLE
feat: add eslint:recommended and more base config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 const config = {
     env: {
-        es6: true,
-        jest: true,
-        browser: true,
-        node: true
+        es6: true
     },
     plugins: ['jsx-a11y', 'package-json', 'react', 'react-hooks'],
     extends: [
@@ -13,14 +10,12 @@ const config = {
         'plugin:package-json/recommended'
     ],
     rules: {
-        'getter-return': 'off',
         'prefer-const': 'error',
         'no-console': 'off',
-        'no-empty': 'off',
         'no-unused-vars': 'error',
         'react/jsx-uses-vars': 'error',
         'react/jsx-uses-react': 'error',
-        'react-hooks/exhaustive-deps': 'warn',
+        'react-hooks/exhaustive-deps': 'error',
         'react-hooks/rules-of-hooks': 'error'
     }
 };

--- a/index.js
+++ b/index.js
@@ -1,8 +1,22 @@
 const config = {
+    env: {
+        es6: true,
+        jest: true,
+        browser: true,
+        node: true
+    },
     plugins: ['jsx-a11y', 'package-json', 'react', 'react-hooks'],
-    extends: ['plugin:jsx-a11y/recommended', 'plugin:package-json/recommended'],
+    extends: [
+        'eslint:recommended',
+        'prettier',
+        'plugin:jsx-a11y/recommended',
+        'plugin:package-json/recommended'
+    ],
     rules: {
+        'getter-return': 'off',
         'prefer-const': 'error',
+        'no-console': 'off',
+        'no-empty': 'off',
         'no-unused-vars': 'error',
         'react/jsx-uses-vars': 'error',
         'react/jsx-uses-react': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -379,6 +379,15 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",
+      "integrity": "sha512-vDrcCFE3+2ixNT5H83g28bO/uYAwibJxerXPj+E7op4qzBCsAV36QfvdAyVOoNxKAH2Os/e01T/2x++V0LPukA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.2.tgz",
@@ -594,6 +603,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -862,7 +877,7 @@
     },
     "minimist": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "(OSL-3.0 OR AFL-3.0)",
   "devDependencies": {
     "eslint": "^5.16.0",
+    "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-package-json": "^0.1.1",
     "eslint-plugin-react": "^7.9.1",
@@ -28,6 +29,7 @@
     "prettier-check": "^2.0.0"
   },
   "peerDependencies": {
+    "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-package-json": "^0.1.1",
     "eslint-plugin-react": "^7.5.1",


### PR DESCRIPTION
Some basic and useful rules are missing from the current `@magento/eslint-config`, such as `no-undef` to catch ReferenceErrors and `no-debugger` to avoid committing debug statements. These rules are part of `eslint:recommended` and this PR just mixes that preset into what we have already.